### PR TITLE
Aggiornato il nome del profilo e il readme

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 ------------------
 
 - Fix pagination styles [nzambello]
+- Updated default profile name [pnicolli]
 
 
 2.1.2 (2018-05-28)

--- a/README.rst
+++ b/README.rst
@@ -8,13 +8,13 @@ redturtle.agidtheme
 
 Il primo tema Plone conforme a `Italia design system`__.
 
-__ https://italia.github.io/design-react-kit/
+__ https://design-italia.readthedocs.io/it/stable/index.html
 
 Questo tema si basa sulla versione 2017.1 delle linee guida.
 
 |
 
-This is the first Plone theme for `AgID`__ guidelines.
+This is the first Plone theme that is compliant with the `Italia design system`__ guidelines.
 
 __ https://design-italia.readthedocs.io/it/stable/index.html
 
@@ -26,7 +26,7 @@ This README is written in italian language because it's meant for Italian Public
 Documentazione
 --------------
 
-Una completa documentazione è disponibile in `questo documento`__.
+La documentazione per l'utente finale è disponibile in `questo documento`__.
 
 __ https://docs.google.com/document/d/1ncSgzj0JABBWR1Jt7sxtIH5qwjCVN10qBm7uA8uM5cw/export?format=pdf
 
@@ -39,10 +39,12 @@ Questo tema può essere visto in azione nei seguenti siti web:
 - `digitale.regione.emilia-romagna.it`__
 - `regione.emilia-romagna.it`__
 - `comune.santarcangelo.rn.it`__
+- `comune.calderaradireno.bo.it`__
 
 __ http://digitale.regione.emilia-romagna.it
 __ http://www.regione.emilia-romagna.it
 __ http://www.comune.santarcangelo.rn.it
+__ http://www.comune.calderaradireno.bo.it
 
 
 Traduzioni
@@ -68,15 +70,17 @@ Installa redturtle.agidtheme aggiungendolo al tuo buildout::
 
 e successivamente eseguendo ``bin/buildout``.
 
+Al successivo avvio del sito troverete il tema disponibile tra i prodotti aggiuntivi del sito, con il nome "Tema: Italia design system".
+
 
 Sviluppo
 --------
 
 Per la compilazione del codice Sass e la build del bundle JavaScript, sono presenti alcuni script nel ``package.json``:
 
-- ``yarn develop``: esegue la compilazione con grunt e farlo restare in watch
-- ``yarn build``: compila con grunt e avviare prettier
-- ``yarn test``: avvia il linting con stylelint.
+- ``yarn develop``: esegue la compilazione con grunt e lo lascia avviato in modalità watch
+- ``yarn build``: compila con grunt e esegue prettier
+- ``yarn test``: esegue il linting con stylelint.
 
 
 Compatibilità

--- a/src/redturtle/agidtheme/configure.zcml
+++ b/src/redturtle/agidtheme/configure.zcml
@@ -27,18 +27,18 @@
 
   <genericsetup:registerProfile
       name="default"
-      title="RedTurtle Agid Theme"
+      title="Tema: Italia design system"
       directory="profiles/default"
-      description="Installs the Plone theme package redturtle.agidtheme."
+      description="Installa il tema basato sulle linee guida italiane per le PA."
       provides="Products.GenericSetup.interfaces.EXTENSION"
       post_handler=".setuphandlers.post_install"
       />
 
   <genericsetup:registerProfile
       name="uninstall"
-      title="Uninstall: RedTurtle Agid Theme"
+      title="Disinstalla: Tema: Italia design system"
       directory="profiles/uninstall"
-      description="Uninstalls the Plone theme package redturtle.agidtheme."
+      description="Disinstalla il tema basato sulle linee guida italiane per le PA."
       provides="Products.GenericSetup.interfaces.EXTENSION"
       post_handler=".setuphandlers.uninstall"
       />


### PR DESCRIPTION
Ho cambiato il nome del profilo affinché non citi direttamente il nome dell'addon, dato che è usato anche come dipendenza di [design-plone-theme](https://github.com/PloneGov-IT/design-plone-theme). Inoltre, ho rimosso riferimenti diretti ad AgID perché lo scope delle linee guida è più ampio, riguarda anche altri gruppi e tutto il sistema è più comunemente chiamato *Italia design system*.
Ho aggiornato il readme di conseguenza.